### PR TITLE
Fix: get app dir from native part to initialize Gno's structures

### DIFF
--- a/framework/call.go
+++ b/framework/call.go
@@ -8,15 +8,23 @@ import (
 	ctypes "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
-	"github.com/gnolang/gno/tm2/pkg/crypto/keys/client"
 	"github.com/gnolang/gno/tm2/pkg/errors"
 	"github.com/gnolang/gno/tm2/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
+// From https://github.com/gnolang/gno/blob/master/tm2/pkg/crypto/keys/client/common.go
+type BaseOptions struct {
+	Home                  string
+	Remote                string
+	Quiet                 bool
+	InsecurePasswordStdin bool
+	Config                string
+}
+
 // From https://github.com/gnolang/gno/blob/master/tm2/pkg/crypto/keys/client/root.go
 type baseCfg struct {
-	client.BaseOptions
+	BaseOptions
 }
 
 // From https://github.com/gnolang/gno/blob/master/tm2/pkg/crypto/keys/client/maketx.go

--- a/framework/gnokey.go
+++ b/framework/gnokey.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
-	"github.com/gnolang/gno/tm2/pkg/crypto/keys/client"
 )
 
 type PromiseBlock interface {
@@ -19,8 +18,8 @@ type accountAndTxCfg struct {
 	Password string
 }
 
-func Hello(name string) string {
-	cfg := getAccountAndTxCfg()
+func Hello(rootDir string) string {
+	cfg := getAccountAndTxCfg(rootDir)
 
 	// Debug: We should only have to do this once. It seems that the Keybase dir is deleted when we reinstall the app.
 	kb, err := keys.NewKeyBaseFromDir(cfg.TxCfg.rootCfg.Home)
@@ -43,8 +42,8 @@ func Hello(name string) string {
 	return fmt.Sprintf("Posted: %s", message)
 }
 
-func getAccountAndTxCfg() *accountAndTxCfg {
-	dataDir := "data"
+func getAccountAndTxCfg(rootDir string) *accountAndTxCfg {
+	dataDir := rootDir + "/data"
 	remote := "testnet.gno.berty.io:26657"
 	chainID := "dev"
 	keyName := "jefft0"
@@ -53,7 +52,7 @@ func getAccountAndTxCfg() *accountAndTxCfg {
 	return &accountAndTxCfg{
 		TxCfg: &makeTxCfg{
 			rootCfg: &baseCfg{
-				BaseOptions: client.BaseOptions{
+				BaseOptions: BaseOptions{
 					Home:   dataDir,
 					Remote: remote,
 				},

--- a/gnoboard/android/app/src/main/java/land/gno/gnoboard/MainApplication.java
+++ b/gnoboard/android/app/src/main/java/land/gno/gnoboard/MainApplication.java
@@ -16,6 +16,7 @@ import com.facebook.soloader.SoLoader;
 import expo.modules.ApplicationLifecycleDispatcher;
 import expo.modules.ReactNativeHostWrapper;
 import land.gno.gobridge.GoBridgePackage;
+import land.gno.rootdir.RootDirPackage;
 
 import java.util.List;
 
@@ -34,6 +35,7 @@ public class MainApplication extends Application implements ReactApplication {
         List<ReactPackage> packages = new PackageList(this).getPackages();
         // Packages that cannot be autolinked yet can be added manually here, for example:
         // packages.add(new MyReactNativePackage());
+          packages.add(new RootDirPackage());
           packages.add(new GoBridgePackage());
         return packages;
       }

--- a/gnoboard/android/app/src/main/java/land/gno/gobridge/GoBridgeModule.java
+++ b/gnoboard/android/app/src/main/java/land/gno/gobridge/GoBridgeModule.java
@@ -14,10 +14,13 @@ import gnoland.gno.gnomobile.Gnomobile;
 public class GoBridgeModule extends ReactContextBaseJavaModule {
     private final static String TAG = "GoBridge";
     private final ReactApplicationContext reactContext;
+    private final File rootDir;
 
     public GoBridgeModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
+
+        rootDir = new File(new land.gno.rootdir.RootDirModule(reactContext).getRootDir());
     }
 
     @Override
@@ -49,7 +52,7 @@ public class GoBridgeModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void hello(String name, Promise promise) {
-        promise.resolve(Gnomobile.hello(name));
+        promise.resolve(Gnomobile.hello(rootDir.getAbsolutePath()));
     }
 
     @Override

--- a/gnoboard/android/app/src/main/java/land/gno/rootdir/RootDirModule.java
+++ b/gnoboard/android/app/src/main/java/land/gno/rootdir/RootDirModule.java
@@ -1,0 +1,37 @@
+package land.gno.rootdir;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+import java.io.File;
+
+public class RootDirModule extends ReactContextBaseJavaModule {
+    private final static String nameFolder = "gnomobile";
+
+    public RootDirModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    public String getRootDir() {
+        String rootDir = getReactApplicationContext().getFilesDir().getAbsolutePath();
+        return new File(rootDir + "/" + nameFolder).getAbsolutePath();
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "RootDir";
+    }
+
+    @ReactMethod
+    public void get(Promise promise) {
+        promise.resolve(getRootDir());
+    }
+}
+

--- a/gnoboard/android/app/src/main/java/land/gno/rootdir/RootDirPackage.java
+++ b/gnoboard/android/app/src/main/java/land/gno/rootdir/RootDirPackage.java
@@ -1,0 +1,21 @@
+package land.gno.rootdir;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.Collections;
+import java.util.List;
+
+public class RootDirPackage implements ReactPackage {
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        return Collections.singletonList(new RootDirModule(reactContext));
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/gnoboard/ios/Sources/RootDir/RootDir.m
+++ b/gnoboard/ios/Sources/RootDir/RootDir.m
@@ -1,0 +1,15 @@
+//
+//  RootDir.m
+//  Berty
+//
+//  Created by Antoine Eddi on 09/08/2021.
+//
+
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(RootDir, NSObject)
+
+RCT_EXTERN_METHOD(get:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject);
+
+@end

--- a/gnoboard/ios/Sources/RootDir/RootDir.swift
+++ b/gnoboard/ios/Sources/RootDir/RootDir.swift
@@ -1,0 +1,44 @@
+//
+//  RootDir.swift
+//  Berty
+//
+//  Created by Antoine Eddi on 09/08/2021.
+//
+
+import Foundation
+
+enum RootDirError: Error {
+    case path
+}
+extension RootDirError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .path:
+            return NSLocalizedString(
+                "unable to get app group path url",
+                comment: ""
+            )
+        }
+    }
+}
+
+func RootDirGet() throws -> String {
+  
+  let docDir = try! FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+  return docDir.appendingPathComponent("gnomobile", isDirectory: true).path
+}
+
+@objc(RootDir)
+class RootDir: NSObject {
+  @objc func get(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    do {
+      resolve(try RootDirGet())
+    } catch {
+      reject("root_dir_failure", error.localizedDescription, error)
+    }
+  }
+  
+  @objc static func requiresMainQueueSetup() -> Bool {
+      return false
+  }
+}

--- a/gnoboard/ios/gnoboard.xcodeproj/project.pbxproj
+++ b/gnoboard/ios/gnoboard.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		8AB3905D2A85BA7D00CB681E /* GoBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB3905B2A85BA7C00CB681E /* GoBridge.m */; };
 		8AB3905E2A85BA7D00CB681E /* GoBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB3905C2A85BA7C00CB681E /* GoBridge.swift */; };
 		8AB390602A85BD6000CB681E /* PromiseBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB3905F2A85BD6000CB681E /* PromiseBlock.swift */; };
+		8AF1F6892A98ABBA0073D4D1 /* RootDir.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AF1F6872A98ABBA0073D4D1 /* RootDir.m */; };
+		8AF1F68A2A98ABBA0073D4D1 /* RootDir.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF1F6882A98ABBA0073D4D1 /* RootDir.swift */; };
 		96905EF65AED1B983A6B3ABC /* libPods-gnoboard.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-gnoboard.a */; };
 		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
@@ -36,6 +38,8 @@
 		8AB3905B2A85BA7C00CB681E /* GoBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GoBridge.m; sourceTree = "<group>"; };
 		8AB3905C2A85BA7C00CB681E /* GoBridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoBridge.swift; sourceTree = "<group>"; };
 		8AB3905F2A85BD6000CB681E /* PromiseBlock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseBlock.swift; sourceTree = "<group>"; };
+		8AF1F6872A98ABBA0073D4D1 /* RootDir.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RootDir.m; sourceTree = "<group>"; };
+		8AF1F6882A98ABBA0073D4D1 /* RootDir.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootDir.swift; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = gnoboard/SplashScreen.storyboard; sourceTree = "<group>"; };
 		B11419FF73544E34A5C7A3A2 /* gnoboard-Bridging-Header.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; name = "gnoboard-Bridging-Header.h"; path = "gnoboard/gnoboard-Bridging-Header.h"; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
@@ -116,6 +120,7 @@
 		8AB390582A85B9B800CB681E /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				8AF1F6862A98ABBA0073D4D1 /* RootDir */,
 				8AB3905A2A85BA7C00CB681E /* Bridge */,
 			);
 			path = Sources;
@@ -131,6 +136,15 @@
 			name = Bridge;
 			path = gnoboard/Sources/Bridge;
 			sourceTree = SOURCE_ROOT;
+		};
+		8AF1F6862A98ABBA0073D4D1 /* RootDir */ = {
+			isa = PBXGroup;
+			children = (
+				8AF1F6872A98ABBA0073D4D1 /* RootDir.m */,
+				8AF1F6882A98ABBA0073D4D1 /* RootDir.swift */,
+			);
+			path = RootDir;
+			sourceTree = "<group>";
 		};
 		92DBD88DE9BF7D494EA9DA96 /* gnoboard */ = {
 			isa = PBXGroup;
@@ -363,6 +377,8 @@
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */,
 				3310DF473105470FBA4883B6 /* noop-file.swift in Sources */,
+				8AF1F68A2A98ABBA0073D4D1 /* RootDir.swift in Sources */,
+				8AF1F6892A98ABBA0073D4D1 /* RootDir.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/gnoboard/ios/gnoboard/Sources/Bridge/GoBridge.swift
+++ b/gnoboard/ios/gnoboard/Sources/Bridge/GoBridge.swift
@@ -3,11 +3,14 @@ import GnoCore
 
 @objc(GoBridge)
 class GoBridge: NSObject {
+    let appRootDir: String
+
     static func requiresMainQueueSetup() -> Bool {
         return true
     }
 
     override init() {
+        self.appRootDir = try! RootDirGet()
         super.init()
     }
 
@@ -40,7 +43,7 @@ class GoBridge: NSObject {
 
   @objc func hello(_ name: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
       do {
-          resolve(GnoGnomobileHello(name))
+        resolve(GnoGnomobileHello(self.appRootDir))
       } catch let error as NSError {
           reject("\(String(describing: error.code))", error.userInfo.description, error)
       }

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/gnolang/gnomobile
 go 1.20
 
 require (
-	github.com/gnolang/gno v0.0.0-20230817171108-b40ac9cda5a5
+	github.com/gnolang/gno v0.0.0-20230824160121-aa7c1df119cd
 	golang.org/x/mobile v0.0.0-20230531173138-3c911d8e3eda
 )
 
 require (
 	github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c // indirect
-	github.com/btcsuite/btcd/btcutil v1.1.1 // indirect
+	github.com/btcsuite/btcd/btcutil v1.0.0 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/cockroachdb/apd v1.1.0 // indirect
@@ -17,6 +17,7 @@ require (
 	github.com/dgraph-io/badger/v3 v3.2103.4 // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/gnolang/cors v1.8.1 // indirect
 	github.com/gnolang/goleveldb v0.0.9 // indirect
 	github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216 // indirect
@@ -31,7 +32,6 @@ require (
 	github.com/klauspost/compress v1.12.3 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/linxGnu/grocksdb v1.7.15 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/peterbourgon/ff/v3 v3.4.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -50,7 +50,4 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 )
 
-replace (
-	github.com/btcsuite/btcd/btcutil v1.1.1 => github.com/btcsuite/btcd/btcutil v1.0.0
-	golang.org/x/mobile => github.com/berty/mobile v0.0.11 // temporary, see https://github.com/golang/mobile/pull/58 and https://github.com/golang/mobile/pull/82
-)
+replace golang.org/x/mobile => github.com/berty/mobile v0.0.11 // temporary, see https://github.com/golang/mobile/pull/58 and https://github.com/golang/mobile/pull/82

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gnolang/cors v1.8.1 h1:D3y1DMoWcgGpCefHwD4UHjy1w1163sfczZyy7b5wH8o=
 github.com/gnolang/cors v1.8.1/go.mod h1:g7HJhHH+N1r+oRrb7ckR2J6xp5es4EizpAP0JpfgVgU=
-github.com/gnolang/gno v0.0.0-20230817171108-b40ac9cda5a5 h1:RHT4qC+etrC144HgB1YKin+QEn3eeR9igZ1rI6j+6Kg=
-github.com/gnolang/gno v0.0.0-20230817171108-b40ac9cda5a5/go.mod h1:UOqlXB96pTBqIvzvFjtrZ1QTmDzupj6ZgtgnA/Pv65k=
+github.com/gnolang/gno v0.0.0-20230824160121-aa7c1df119cd h1:mHDNPrio9ih/rB0ASAEcE0hcajzxT0012tWENTBtsyE=
+github.com/gnolang/gno v0.0.0-20230824160121-aa7c1df119cd/go.mod h1:XXHIVMAtlkT+97nrgLLcwE8nQgFUDJUJ7wUYRZsdD/I=
 github.com/gnolang/goleveldb v0.0.9 h1:Q7rGko9oXMKtQA+Apeeed5a3sjba/mcDhzJGoTVLCKE=
 github.com/gnolang/goleveldb v0.0.9/go.mod h1:Dz6p9bmpy/FBESTgduiThZt5mToVDipcHGzj/zUOo8E=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216 h1:GKvsK3oLWG9B1GL7WP/VqwM6C92j5tIvB844oggL9Lk=
@@ -106,7 +106,6 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
-github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=


### PR DESCRIPTION
This PR fixes a crash when I try to run the gnoboard app on Android and on some iOS devices.
The Gno configuration struct `BaseOptions` needs a `dataDir` path to create files. The default `HomeDir()` function provided in `tm2/pkg/crypto/keys/client/common.go` to get that path doesn't work on mobile and causes a `panic`, because some environment variables are not set on mobile.
The `HomeDir` function is called every time the `tm2/pkg/crypto/keys/client` subfolder is imported because of the global variable `DefaultBaseOptions` that calls `Homedir`. To avoid the call of the `HomeDir` function that calls a `panic`, we duplicated `BaseOptions` in **gnomobile**, so the  `tm2/pkg/crypto/keys/client` is no more imported and we provided it the app container path directory from the Android/iOS native parts.

This PR also updates the `go.mod` to use the latest version of **Gno** that fixes the ambiguous import of the `btcd` dependencies.