### PR TITLE
chore: In README, clone with https, not git protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Start a new terminal to get the changes to the environment .
 ### Get a copy of the repo
 
 ```console
-git clone git@github.com:gnolang/gnomobile.git
+git clone https://github.com/gnolang/gnomobile
 cd gnomobile
 ```
 


### PR DESCRIPTION
The README currently says `git clone git@github.com:gnolang/gnomobile.git`. But the `git@` protocol requires the user to be logged in to GitHub (or have keys set up on the platform). This makes testing on new platforms difficult. This pull request changes to clone with the https protocol which does not require a user account.