### PR TITLE
feat: export listKeyInfo, createAccount and selectAccount to RN

### DIFF
--- a/gnoboard/android/app/src/main/java/land/gno/rootdir/RootDirModule.java
+++ b/gnoboard/android/app/src/main/java/land/gno/rootdir/RootDirModule.java
@@ -19,8 +19,7 @@ public class RootDirModule extends ReactContextBaseJavaModule {
     }
 
     public String getRootDir() {
-        String rootDir = getReactApplicationContext().getFilesDir().getAbsolutePath();
-        return new File(rootDir + "/" + nameFolder).getAbsolutePath();
+        return getReactApplicationContext().getFilesDir().getAbsolutePath();
     }
 
     @NonNull

--- a/gnoboard/ios/Podfile.lock
+++ b/gnoboard/ios/Podfile.lock
@@ -833,14 +833,14 @@ SPEC CHECKSUMS:
   React-Core: 34da8c952844e21f5a69bf46438fb6bf063900d0
   React-CoreModules: 621243df8863055ff30f3bb2ff71573ffa7b16c8
   React-cxxreact: 4ad1cc861e32fb533dad6ff7a4ea25680fa1c994
-  React-debug: 87e536bf904d3c1ebaf00858ccccd3e420a38d2c
+  React-debug: 06f921e33f3f940a392052012cfb256051c9a275
   React-hermes: 37377d0a56aa0cf55c65248271866ce3268cde3f
   React-jsi: 6de8b0ccc6b765b58e4eee9ee38049dbeaf5c221
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
   react-native-safe-area-context: 36cc67648134e89465663b8172336a19eeda493d
-  React-NativeModulesApple: a5f7ebe17ca44f8209960cc1ba242d2475154087
+  React-NativeModulesApple: 746d5d0dd491886547c9070ab2d0e9faf12e79f2
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
   React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00
   React-RCTAnimation: e44fe5053708c5be762943087c78dc5a6a3c645c
@@ -854,9 +854,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: 35eec7201c8ffdaccdd908a5ec874b7055f975f3
   React-rncore: 46133d523155fc84572338bd6a7c461c1d873efc
   React-runtimeexecutor: d465ba0c47ef3ed8281143f59605cacc2244d5c7
-  React-runtimescheduler: 8d0d60581794ff5b5f169cfe04687b90fc69d4f3
-  React-utils: 5809e4db95639f02aec7998455856170cbaaa00f
-  ReactCommon: 454d20eb5d0668177d448b1d4f3e43bf66578f8e
+  React-runtimescheduler: 353534caf9e86a801060c8c206f1030e693398c4
+  React-utils: e7b50b9df8e6b38bef66cc5305bb690c7e9bbbe8
+  ReactCommon: 18bd1d7ca7ad6771a9168d3ab7ccf696593e424b
   RNScreens: 50ffe2fa2342eabb2d0afbe19f7c1af286bc7fb3
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24

--- a/gnoboard/ios/gnoboard/Sources/Bridge/GoBridge.m
+++ b/gnoboard/ios/gnoboard/Sources/Bridge/GoBridge.m
@@ -9,6 +9,22 @@ RCT_EXTERN_METHOD(initBridge:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(closeBridge:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject);
 
+RCT_EXTERN_METHOD(listKeyInfo:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject);
+
+RCT_EXTERN_METHOD(createAccount:(NSString *)nameOrBech32
+                  mnemonic:(NSString *)mnemonic
+                  bip39Passwd:(NSString *)bip39Passwd
+                  password:(NSString *)password
+                  account:(nonnull NSNumber *)account
+                  index:(nonnull NSNumber *)index
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject);
+
+RCT_EXTERN_METHOD(selectAccount:(NSString *)nameOrBech32
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject);
+
 RCT_EXTERN_METHOD(call:(NSString *)packagePath
                   fnc:(NSString *)fnc
                   args:(NSArray *)args

--- a/gnoboard/src/native_modules/GoBridge.ts
+++ b/gnoboard/src/native_modules/GoBridge.ts
@@ -9,7 +9,33 @@ class NoopGoBridge implements GoBridgeInterface {
     return Promise.reject();
   }
 
-  call(packagePath: string, fnc: string, args: Array<string>, gasFee: string, gasWanted: Number, password: string): Promise<string> {
+  listKeyInfo(): Promise<Array<string>> {
+    return Promise.reject();
+  }
+
+  createAccount(
+    _nameOrBech32: string,
+    _mnemonic: string,
+    _bip39Passw: string,
+    _password: string,
+    _account: Number,
+    _index: Number,
+  ): Promise<string> {
+    return Promise.reject();
+  }
+
+  selectAccount(_nameOrBech32: string): Promise<string> {
+    return Promise.reject();
+  }
+
+  call(
+    _packagePath: string,
+    _fnc: string,
+    _args: Array<string>,
+    _gasFee: string,
+    _gasWanted: Number,
+    _password: string,
+  ): Promise<string> {
     return Promise.reject();
   }
 

--- a/gnoboard/src/native_modules/GoBridgeInterface.ts
+++ b/gnoboard/src/native_modules/GoBridgeInterface.ts
@@ -1,6 +1,23 @@
 export interface GoBridgeInterface {
   initBridge(): Promise<void>;
   closeBridge(): Promise<void>;
-  call(packagePath: string, fnc: string, args: Array<string>, gasFee: string, gasWanted: Number, password: string): Promise<string>;
+  listKeyInfo(): Promise<Array<string>>;
+  createAccount(
+    nameOrBech32: string,
+    mnemonic: string,
+    bip39Passw: string,
+    password: string,
+    account: Number,
+    index: Number,
+  ): Promise<string>;
+  selectAccount(nameOrBech32: string): Promise<string>;
+  call(
+    packagePath: string,
+    fnc: string,
+    args: Array<string>,
+    gasFee: string,
+    gasWanted: Number,
+    password: string,
+  ): Promise<string>;
   exportJsonConfig(): Promise<string>;
 }

--- a/gnoboard/src/screens/home/index.tsx
+++ b/gnoboard/src/screens/home/index.tsx
@@ -3,9 +3,14 @@ import { ConsoleView } from "@gno/components/consoleview";
 import TextInput from "@gno/components/textinput";
 import { GoBridge } from "@gno/native_modules";
 import { screenStyleSheet as styles } from "@gno/styles";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Linking, ScrollView, StyleSheet, Text, View } from "react-native";
-import { initBridge } from "@gno/utils/bridge";
+import {
+  createAccount,
+  initBridge,
+  listKeyInfo,
+  selectAccount,
+} from "@gno/utils/bridge";
 
 function HomeScreen() {
   const [postContent, setPostContent] = useState("");
@@ -13,33 +18,45 @@ function HomeScreen() {
   const [loading, setLoading] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-  	const init = async () => {
-	  await initBridge()
-	}
-	init()
+    const init = async () => {
+      await initBridge();
+      let listKey = await listKeyInfo();
+      if (listKey.length === 0) {
+        await createAccount(
+          "jefft0",
+          "enable until hover project know foam join table educate room better scrub clever powder virus army pitch ranch fix try cupboard scatter dune fee",
+          "",
+          "password",
+          0,
+          0,
+        );
+      }
+      await selectAccount("jefft0");
+    };
+    init();
 
-	return () => {
-		const deinit = async () => {
-		  await GoBridge.closeBridge()
-		}
-		deinit()
-	}
-  }, [])
+    return () => {
+      const deinit = async () => {
+        await GoBridge.closeBridge();
+      };
+      deinit();
+    };
+  }, []);
 
   const onPostPress = async () => {
     setLoading("Replying to a post...");
     setAppConsole("replying to a post...");
-    var gasFee = "1000000ugnot"
-    var gasWanted = 2000000
-	var args: Array<string> = ["2", "1", "1", postContent]
+    var gasFee = "1000000ugnot";
+    var gasWanted = 2000000;
+    var args: Array<string> = ["2", "1", "1", postContent];
     GoBridge.call(
-		"gno.land/r/demo/boards",
-		"CreateReply",
-		args,
-		gasFee,
-		gasWanted,
-		"password"
-	)
+      "gno.land/r/demo/boards",
+      "CreateReply",
+      args,
+      gasFee,
+      gasWanted,
+      "password",
+    )
       .then((data) => {
         setAppConsole(data);
         setPostContent("");
@@ -66,7 +83,7 @@ function HomeScreen() {
 
   const loadInBrowser = () => {
     Linking.openURL(
-      "http://testnet.gno.berty.io/r/demo/boards:gnomobile/1"
+      "http://testnet.gno.berty.io/r/demo/boards:gnomobile/1",
     ).catch((err) => console.error("Couldn't load page", err));
   };
 

--- a/gnoboard/src/utils/bridge.ts
+++ b/gnoboard/src/utils/bridge.ts
@@ -1,20 +1,74 @@
-import { GoBridge } from '@gno/native_modules';
+import { GoBridge } from "@gno/native_modules";
 
 export const initBridge = async (): Promise<boolean> => {
-	try {
-		console.log('bridge methods: ', Object.keys(GoBridge))
+  try {
+    console.log("bridge methods: ", Object.keys(GoBridge));
 
-		await GoBridge.initBridge()
+    await GoBridge.initBridge();
 
-		return true
-	} catch (err: any) {
-		if (err?.message?.indexOf('already instantiated') !== -1) {
-			console.log('bridge already started: ', err)
-			return true
-		} else {
-			console.error('unable to init bridge: ', err)
-		}
+    return true;
+  } catch (err: any) {
+    if (err?.message?.indexOf("already instantiated") !== -1) {
+      console.log("bridge already started: ", err);
+      return true;
+    } else {
+      console.error("unable to init bridge: ", err);
+    }
 
-		return false
-	}
-}
+    return false;
+  }
+};
+
+export const closeBridge = async (): Promise<boolean> => {
+  try {
+    await GoBridge.closeBridge();
+    return true;
+  } catch (err: any) {
+    console.error("unable to close bridge: ", err);
+    return false;
+  }
+};
+
+export const listKeyInfo = async (): Promise<string[]> => {
+  try {
+    const keys = await GoBridge.listKeyInfo();
+    return keys;
+  } catch (err: any) {
+    console.error("unable to list keys: ", err);
+    return [];
+  }
+};
+
+export const createAccount = async (
+  nameOrBech32: string,
+  mnemonic: string,
+  bip39Passw: string,
+  password: string,
+  account: Number,
+  index: Number,
+): Promise<string> => {
+  try {
+    const addr = await GoBridge.createAccount(
+      nameOrBech32,
+      mnemonic,
+      bip39Passw,
+      password,
+      account,
+      index,
+    );
+    return addr;
+  } catch (err: any) {
+    console.error("unable to close bridge: ", err);
+    return "";
+  }
+};
+
+export const selectAccount = async (nameOrBech32: string): Promise<string> => {
+  try {
+    const addr = await GoBridge.selectAccount(nameOrBech32);
+    return addr;
+  } catch (err: any) {
+    console.error("unable to close bridge: ", err);
+    return "";
+  }
+};

--- a/service/api.go
+++ b/service/api.go
@@ -23,7 +23,7 @@ func (s *gnomobileService) SetChainID(ctx context.Context, req *rpc.SetChainID_R
 }
 
 // Set the nameOrBech32 for the account in the keybase, used for later operations
-func (s *gnomobileService) SetNameOrBench32(ctx context.Context, req *rpc.SetNameOrBech32_Request) (*rpc.SetNameOrBech32_Reply, error) {
+func (s *gnomobileService) SetNameOrBech32(ctx context.Context, req *rpc.SetNameOrBech32_Request) (*rpc.SetNameOrBech32_Reply, error) {
 	s.client.SetNameOrBech32(req.NameOrBech32)
 	return &rpc.SetNameOrBech32_Reply{}, nil
 }
@@ -60,6 +60,8 @@ func convertKeyInfo(key crypto_keys.Info) (*rpc.KeyInfo, error) {
 
 // Get the keys informations in the keybase
 func (s *gnomobileService) ListKeyInfo(ctx context.Context, req *rpc.ListKeyInfo_Request) (*rpc.ListKeyInfo_Reply, error) {
+	s.logger.Debug("ListKeyInfo called")
+
 	keys, err := s.client.GetKeys()
 	if err != nil {
 		return nil, err
@@ -81,6 +83,8 @@ func (s *gnomobileService) ListKeyInfo(ctx context.Context, req *rpc.ListKeyInfo
 
 // Create a new account in the keybase
 func (s *gnomobileService) CreateAccount(ctx context.Context, req *rpc.CreateAccount_Request) (*rpc.CreateAccount_Reply, error) {
+	s.logger.Debug("CreateAccount called", zap.String("NameOrBech32", req.NameOrBech32))
+
 	key, err := s.client.CreateAccount(req.NameOrBech32, req.Mnemonic, req.Bip39Passwd, req.Password, req.Account, req.Index)
 	if err != nil {
 		return nil, err
@@ -96,6 +100,8 @@ func (s *gnomobileService) CreateAccount(ctx context.Context, req *rpc.CreateAcc
 
 // SelectAccount selects the account to use for later operations
 func (s *gnomobileService) SelectAccount(ctx context.Context, req *rpc.SelectAccount_Request) (*rpc.SelectAccount_Reply, error) {
+	s.logger.Debug("SelectAccount called", zap.String("NameOrBech32", req.NameOrBech32))
+
 	key, err := s.client.GetKeyByNameOrBech32(req.NameOrBech32)
 	if err != nil {
 		return nil, rpc.ErrCode_ErrCryptoKeyNotFound


### PR DESCRIPTION
In the meantime we implement a TS gRPC client, we expose three methods to manage accounts:
- listKeyInfo
- createAccount
- selectAccount

So the frontend team can continue to work on these functionalities.