### PR TITLE
chore: Add service.Config used by gnomobileService

### DIFF
--- a/framework/bridge.go
+++ b/framework/bridge.go
@@ -63,7 +63,7 @@ func NewBridge(config *BridgeConfig) (*Bridge, error) {
 		svcOpts = append(svcOpts,
 			service.WithRootDir(config.RootDir),
 			service.WithTmpDir(config.TmpDir),
-			service.WithTcpListener(config.UseTcpListener),
+			service.WithUseTcpListener(config.UseTcpListener),
 		)
 
 		serviceServer, err := service.NewGnomobileService(svcOpts...)


### PR DESCRIPTION
Similar to libp2p Config, define service.Config and use it to initialize gnomobileService. Rename WithTcpListener to WithUseTcpListener for consistency with BridgeConfig.