### PR TITLE
fix: In ListKeyInfo, initialize formatedKeys as zero length, then apppend

### DIFF
--- a/service/api.go
+++ b/service/api.go
@@ -87,7 +87,7 @@ func (s *gnomobileService) ListKeyInfo(ctx context.Context, req *rpc.ListKeyInfo
 		return nil, err
 	}
 
-	formatedKeys := make([]*rpc.KeyInfo, len(keys))
+	formatedKeys := make([]*rpc.KeyInfo, 0)
 
 	for _, key := range keys {
 		info, err := convertKeyInfo(key)


### PR DESCRIPTION
ListKeyInfo maps the key list into an array of Protobuf KeyInfo . We need to initialize `formatedKeys` as zero length, then append as we map the values (if any).