### PR TITLE
Chore: Remember the password in the gnomobileService

### DIFF
--- a/service/api.go
+++ b/service/api.go
@@ -117,10 +117,18 @@ func (s *gnomobileService) SelectAccount(ctx context.Context, req *connect.Reque
 	s.lock.Unlock()
 
 	s.getSigner().Account = req.Msg.NameOrBech32
+	s.getSigner().Password = account.password
 	return connect.NewResponse(&rpc.SelectAccountResponse{Key: info}), nil
 }
 
 func (s *gnomobileService) SetPassword(ctx context.Context, req *connect.Request[rpc.SetPasswordRequest]) (*connect.Response[rpc.SetPasswordResponse], error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.activeAccount == nil {
+		return nil, rpc.ErrCode_ErrNoActiveAccount
+	}
+	s.activeAccount.password = req.Msg.Password
+
 	s.getSigner().Password = req.Msg.Password
 	return connect.NewResponse(&rpc.SetPasswordResponse{}), nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -37,7 +37,8 @@ type GnomobileService interface {
 }
 
 type userAccount struct {
-	keyInfo keys.Info
+	keyInfo  keys.Info
+	password string
 }
 
 type gnomobileService struct {


### PR DESCRIPTION
This PR resolves issue #29. This PR allows the user to remember the account password during the runtime. It's not about storing the password in the OS password manager to recover it later between two app runs.