### PR TITLE
fix: make clean build didn't work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ build.android: generate $(gnocore_aar) $(gnocore_jar)
 # Generate API from protofiles
 generate: api.generate
 
+# Clean and generate
+regenerate: api.clean api.generate
+
 # Clean all generated files
 clean: bind.clean api.clean
 
@@ -59,7 +62,7 @@ fclean: clean
 	rm -rf node_modules
 	rm -rf $(cache_dir)
 
-.PHONY: generate build.ios build.android clean fclean
+.PHONY: generate regenerate build.ios build.android clean fclean
 
 # - API : Handle API generation and cleaning
 
@@ -77,6 +80,7 @@ _api.clean.protocol:
 	rm -f service/rpc/*.pb.go
 	rm -f service/rpc/rpcconnect/*.connect.go
 	rm -f gnoboard/src/api/*.{ts,js}
+	rm -f $(gen_sum)
 
 $(gen_sum): $(gen_src)
 	$(call check-program, shasum buf)

--- a/gen.sum
+++ b/gen.sum
@@ -1,4 +1,4 @@
-32912b23e53cdce4210f1b598f4bdda7a871511d  Makefile
+1e6bd8724e72bd2ac0826580baefa8361925ddeb  Makefile
 de947d5bd943bc6295fed5ad70ecb81547245997  buf.gen.yaml
 1f2a15aa1850917fb6febf82919b9163ca63918c  service/gnomobiletypes/gnomobiletypes.go
 c4488aa6a301b2865856719295d704c77ff45512  service/gnomobiletypes/package.go


### PR DESCRIPTION
Fix `make clean generate` that didn't work.
Add the `regenerate` rule to the Makefile to force the API regeneration.