### PR TITLE
chore: In SetPassword, validate the password

### DIFF
--- a/gen.sum
+++ b/gen.sum
@@ -3,4 +3,4 @@ de947d5bd943bc6295fed5ad70ecb81547245997  buf.gen.yaml
 f1885ad4899d13dd9862536d9561c09b8cf0304d  service/gnomobiletypes/gnomobiletypes.go
 d6482c2dabdab4720f3c7faa9b3a499b7b72626c  service/gnomobiletypes/package.go
 5498f446f6e0cfc4ca2b65cefc6e6cf7ae518857  service/rpc/gnomobiletypes.proto
-66a849655d66aa9a1912f443b84194ee01d3ddaf  service/rpc/rpc.proto
+959d07c3a807ffd3f09606000aa42a5871b6a14d  service/rpc/rpc.proto

--- a/gnoboard/src/api/rpc_connect.d.ts
+++ b/gnoboard/src/api/rpc_connect.d.ts
@@ -160,7 +160,8 @@ export declare const GnomobileService: {
       readonly kind: MethodKind.Unary,
     },
     /**
-     * Set the password for the account in the keybase, used for later operations
+     * Set the password for the account in the keybase, used for later operations.
+     * If the password is wrong, return ErrDecryptionFailed.
      *
      * @generated from rpc land.gno.gnomobile.v1.GnomobileService.SetPassword
      */

--- a/gnoboard/src/api/rpc_connect.js
+++ b/gnoboard/src/api/rpc_connect.js
@@ -160,7 +160,8 @@ export const GnomobileService = {
       kind: MethodKind.Unary,
     },
     /**
-     * Set the password for the account in the keybase, used for later operations
+     * Set the password for the account in the keybase, used for later operations.
+     * If the password is wrong, return ErrDecryptionFailed.
      *
      * @generated from rpc land.gno.gnomobile.v1.GnomobileService.SetPassword
      */

--- a/gnoclient/signer.go
+++ b/gnoclient/signer.go
@@ -3,6 +3,7 @@ package gnoclient
 import (
 	"fmt"
 
+	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
 	"github.com/gnolang/gno/tm2/pkg/errors"
 	"github.com/gnolang/gno/tm2/pkg/std"
@@ -33,7 +34,20 @@ func (s SignerFromKeybase) Validate() error {
 		return err
 	}
 
-	// TODO: Also verify if the password unlocks the account.
+	// To verify if the password unlocks the account, sign a blank transaction.
+	msg := vm.MsgCall{
+		Caller: s.Info().GetAddress(),
+	}
+	signCfg := SignCfg{
+		UnsignedTX: std.Tx{
+			Msgs: []std.Msg{msg},
+			Fee:  std.NewFee(0, std.NewCoin("ugnot", 1000000)),
+		},
+	}
+	if _, err = s.Sign(signCfg); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/service/api.go
+++ b/service/api.go
@@ -239,6 +239,18 @@ func (s *gnomobileService) SetPassword(ctx context.Context, req *connect.Request
 	s.activeAccount.password = req.Msg.Password
 
 	s.getSigner().Password = req.Msg.Password
+
+	// Check the password.
+	if err := s.getSigner().Validate(); err != nil {
+		if keyerror.IsErrKeyNotFound(err) {
+			return nil, rpc.ErrCode_ErrCryptoKeyNotFound
+		} else if keyerror.IsErrWrongPassword(err) {
+			return nil, rpc.ErrCode_ErrDecryptionFailed
+		} else {
+			return nil, err
+		}
+	}
+
 	return connect.NewResponse(&rpc.SetPasswordResponse{}), nil
 }
 

--- a/service/rpc/rpc.proto
+++ b/service/rpc/rpc.proto
@@ -59,7 +59,8 @@ service GnomobileService {
   // SelectAccount selects the active account to use for later operations
   rpc SelectAccount(SelectAccountRequest) returns (SelectAccountResponse);
 
-  // Set the password for the account in the keybase, used for later operations
+  // Set the password for the account in the keybase, used for later operations.
+  // If the password is wrong, return ErrDecryptionFailed.
   rpc SetPassword(SetPasswordRequest) returns (SetPasswordResponse);
 
   // GetActiveAccount gets the active account which was set by SelectAccount.

--- a/service/rpc/rpcconnect/rpc.connect.go
+++ b/service/rpc/rpcconnect/rpc.connect.go
@@ -141,7 +141,8 @@ type GnomobileServiceClient interface {
 	CreateAccount(context.Context, *connect.Request[rpc.CreateAccountRequest]) (*connect.Response[rpc.CreateAccountResponse], error)
 	// SelectAccount selects the active account to use for later operations
 	SelectAccount(context.Context, *connect.Request[rpc.SelectAccountRequest]) (*connect.Response[rpc.SelectAccountResponse], error)
-	// Set the password for the account in the keybase, used for later operations
+	// Set the password for the account in the keybase, used for later operations.
+	// If the password is wrong, return ErrDecryptionFailed.
 	SetPassword(context.Context, *connect.Request[rpc.SetPasswordRequest]) (*connect.Response[rpc.SetPasswordResponse], error)
 	// GetActiveAccount gets the active account which was set by SelectAccount.
 	// If there is no active account, then return ErrNoActiveAccount.
@@ -502,7 +503,8 @@ type GnomobileServiceHandler interface {
 	CreateAccount(context.Context, *connect.Request[rpc.CreateAccountRequest]) (*connect.Response[rpc.CreateAccountResponse], error)
 	// SelectAccount selects the active account to use for later operations
 	SelectAccount(context.Context, *connect.Request[rpc.SelectAccountRequest]) (*connect.Response[rpc.SelectAccountResponse], error)
-	// Set the password for the account in the keybase, used for later operations
+	// Set the password for the account in the keybase, used for later operations.
+	// If the password is wrong, return ErrDecryptionFailed.
 	SetPassword(context.Context, *connect.Request[rpc.SetPasswordRequest]) (*connect.Response[rpc.SetPasswordResponse], error)
 	// GetActiveAccount gets the active account which was set by SelectAccount.
 	// If there is no active account, then return ErrNoActiveAccount.


### PR DESCRIPTION
As we discussed, this PR supports validating the password as follows:
* In the gnoclient Signer `Validate` function, verify if the password unlocks the account by signing a blank transaction.
* In the gRPC `SetPassword` function, call `Validate` and return `ErrDecryptionFailed` if the password is invalid.
* In the gRPC Protobuf api, update the doc comment for `SetPassword`.