### PR TITLE
feat: Use the Buf's ConnectError to throw errors to React-Native

### DIFF
--- a/gnoboard/src/api/error.ts
+++ b/gnoboard/src/api/error.ts
@@ -1,0 +1,60 @@
+import { ErrCode, ErrDetails } from '@gno/api/rpc_pb';
+import { Code, ConnectError } from '@connectrpc/connect';
+
+class GRPCError extends Error {
+  public Details: ErrDetails | undefined;
+  public GrpcCode: Code;
+
+  public error: ConnectError;
+
+  constructor(e: ConnectError | null | undefined) {
+    if (!e) {
+      // this should not happen, but should not break the app either.
+      // instead simply create a empty error and warn about this
+      console.warn(`GRPCError: (${e}) grpc error provided, empty error returned`);
+      e = new ConnectError('');
+    }
+
+    super(e.rawMessage);
+
+    this.error = e;
+    this.GrpcCode = e.code;
+    this.Details = e.findDetails(ErrDetails).shift();
+  }
+
+  public details(): ErrDetails | unknown {
+    return this.Details;
+  }
+
+  public errCode(): ErrCode {
+    if (this.Details === undefined) {
+      return ErrCode.Undefined;
+    }
+
+    const codes = this.Details.codes;
+    if (codes.length == 0) {
+      return ErrCode.Undefined;
+    }
+
+    return codes[0];
+  }
+
+  public grpcErrorCode(): Code {
+    return this.GrpcCode;
+  }
+
+  public toJSON(): any {
+    return {
+      message: this.message,
+      grpcErrorCode: Code[this.GrpcCode],
+      errorCode: ErrCode[this.errCode()],
+      details: this.Details,
+    };
+  }
+
+  public hasErrCode(error: ErrCode): boolean {
+    return this.Details?.codes.reduce((ac, v) => ac && v == error, false) || false;
+  }
+}
+
+export { GRPCError };

--- a/gnoboard/src/screens/wallet/home/index.tsx
+++ b/gnoboard/src/screens/wallet/home/index.tsx
@@ -13,6 +13,9 @@ import { GnoAccount } from '@gno/native_modules/types';
 import { QueryAccountResponse } from '@gno/api/gnomobiletypes_pb';
 import { AccountBalance } from '@gno/components/account';
 import { Spacer } from '@gno/components/row';
+import { ConnectError } from '@connectrpc/connect';
+import { ErrCode } from '@gno/api/rpc_pb';
+import { GRPCError } from '@gno/api/error';
 
 export const Home: React.FC = () => {
   const navigation = useNavigation<RouterWelcomeStackProp>();
@@ -36,8 +39,9 @@ export const Home: React.FC = () => {
           const balance = await gno.queryAccount(response.key.address);
           setBalance(balance);
         }
-      } catch (error: unknown | Error) {
-        if (error?.rawMessage === 'ErrUnknownAddress(#110)') {
+      } catch (error: ConnectError | unknown) {
+        const err = new GRPCError(error);
+        if (err.errCode() === ErrCode.ErrNoActiveAccount) {
           setUnknownAddress(true);
         }
       } finally {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	golang.org/x/mobile v0.0.0-20230531173138-3c911d8e3eda
 	golang.org/x/net v0.17.0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
-	google.golang.org/grpc v1.50.1
 	google.golang.org/protobuf v1.31.0
 )
 
@@ -54,7 +53,6 @@ require (
 	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/tools v0.13.0 // indirect
-	google.golang.org/genproto v0.0.0-20221202195650-67e5cbc046fd // indirect
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -262,16 +262,12 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20221202195650-67e5cbc046fd h1:OjndDrsik+Gt+e6fs45z9AxiewiKyLKYpA45W5Kpkks=
-google.golang.org/genproto v0.0.0-20221202195650-67e5cbc046fd/go.mod h1:cTsE614GARnxrLsqKREzmNYJACSWWpAWdNMwnD7c2BE=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
-google.golang.org/grpc v1.50.1 h1:DS/BukOZWp8s6p4Dt/tOaJaTQyPyOoCcrjroHuCeLzY=
-google.golang.org/grpc v1.50.1/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/service/api.go
+++ b/service/api.go
@@ -83,7 +83,7 @@ func (s *gnomobileService) HasKeyByName(ctx context.Context, req *connect.Reques
 	has, err := s.getSigner().Keybase.HasByName(req.Msg.Name)
 	if err != nil {
 		if keyerror.IsErrKeyNotFound(err) {
-			return nil, rpc.ErrCode_ErrCryptoKeyNotFound
+			return nil, rpc.ErrCode_ErrCryptoKeyNotFound.Grpc()
 		} else {
 			return nil, err
 		}
@@ -98,7 +98,7 @@ func (s *gnomobileService) HasKeyByAddress(ctx context.Context, req *connect.Req
 	has, err := s.getSigner().Keybase.HasByAddress(crypto.AddressFromBytes(req.Msg.Address))
 	if err != nil {
 		if keyerror.IsErrKeyNotFound(err) {
-			return nil, rpc.ErrCode_ErrCryptoKeyNotFound
+			return nil, rpc.ErrCode_ErrCryptoKeyNotFound.Grpc()
 		} else {
 			return nil, err
 		}
@@ -113,7 +113,7 @@ func (s *gnomobileService) HasKeyByNameOrAddress(ctx context.Context, req *conne
 	has, err := s.getSigner().Keybase.HasByNameOrAddress(req.Msg.NameOrBech32)
 	if err != nil {
 		if keyerror.IsErrKeyNotFound(err) {
-			return nil, rpc.ErrCode_ErrCryptoKeyNotFound
+			return nil, rpc.ErrCode_ErrCryptoKeyNotFound.Grpc()
 		} else {
 			return nil, err
 		}
@@ -128,7 +128,7 @@ func (s *gnomobileService) GetKeyInfoByName(ctx context.Context, req *connect.Re
 	key, err := s.getSigner().Keybase.GetByName(req.Msg.Name)
 	if err != nil {
 		if keyerror.IsErrKeyNotFound(err) {
-			return nil, rpc.ErrCode_ErrCryptoKeyNotFound
+			return nil, rpc.ErrCode_ErrCryptoKeyNotFound.Grpc()
 		} else {
 			return nil, err
 		}
@@ -148,7 +148,7 @@ func (s *gnomobileService) GetKeyInfoByAddress(ctx context.Context, req *connect
 	key, err := s.getSigner().Keybase.GetByAddress(crypto.AddressFromBytes(req.Msg.Address))
 	if err != nil {
 		if keyerror.IsErrKeyNotFound(err) {
-			return nil, rpc.ErrCode_ErrCryptoKeyNotFound
+			return nil, rpc.ErrCode_ErrCryptoKeyNotFound.Grpc()
 		} else {
 			return nil, err
 		}
@@ -168,7 +168,7 @@ func (s *gnomobileService) GetKeyInfoByNameOrAddress(ctx context.Context, req *c
 	key, err := s.getSigner().Keybase.GetByNameOrAddress(req.Msg.NameOrBech32)
 	if err != nil {
 		if keyerror.IsErrKeyNotFound(err) {
-			return nil, rpc.ErrCode_ErrCryptoKeyNotFound
+			return nil, rpc.ErrCode_ErrCryptoKeyNotFound.Grpc()
 		} else {
 			return nil, err
 		}
@@ -204,7 +204,7 @@ func (s *gnomobileService) SelectAccount(ctx context.Context, req *connect.Reque
 	// The key may already be in s.userAccounts, but the info may have changed on disk. So always get from disk.
 	key, err := s.getSigner().Keybase.GetByNameOrAddress(req.Msg.NameOrBech32)
 	if err != nil {
-		return nil, rpc.ErrCode_ErrCryptoKeyNotFound
+		return nil, rpc.ErrCode_ErrCryptoKeyNotFound.Grpc()
 	}
 
 	info, err := convertKeyInfo(key)
@@ -234,7 +234,7 @@ func (s *gnomobileService) SetPassword(ctx context.Context, req *connect.Request
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if s.activeAccount == nil {
-		return nil, rpc.ErrCode_ErrNoActiveAccount
+		return nil, rpc.ErrCode_ErrNoActiveAccount.Grpc()
 	}
 	s.activeAccount.password = req.Msg.Password
 
@@ -243,9 +243,9 @@ func (s *gnomobileService) SetPassword(ctx context.Context, req *connect.Request
 	// Check the password.
 	if err := s.getSigner().Validate(); err != nil {
 		if keyerror.IsErrKeyNotFound(err) {
-			return nil, rpc.ErrCode_ErrCryptoKeyNotFound
+			return nil, rpc.ErrCode_ErrCryptoKeyNotFound.Grpc()
 		} else if keyerror.IsErrWrongPassword(err) {
-			return nil, rpc.ErrCode_ErrDecryptionFailed
+			return nil, rpc.ErrCode_ErrDecryptionFailed.Grpc()
 		} else {
 			return nil, err
 		}
@@ -262,7 +262,7 @@ func (s *gnomobileService) GetActiveAccount(ctx context.Context, req *connect.Re
 	s.lock.RUnlock()
 
 	if account == nil {
-		return nil, rpc.ErrCode_ErrNoActiveAccount
+		return nil, rpc.ErrCode_ErrNoActiveAccount.Grpc()
 	}
 
 	info, err := convertKeyInfo(account.keyInfo)
@@ -283,7 +283,7 @@ func (s *gnomobileService) QueryAccount(ctx context.Context, req *connect.Reques
 	account, _, err := s.client.QueryAccount(crypto.AddressFromBytes(req.Msg.Address))
 	if err != nil {
 		if errors.As(err, &std.UnknownAddressError{}) {
-			return nil, rpc.ErrCode_ErrUnknownAddress
+			return nil, rpc.ErrCode_ErrUnknownAddress.Grpc()
 		}
 		return nil, err
 	}
@@ -309,9 +309,9 @@ func (s *gnomobileService) QueryAccount(ctx context.Context, req *connect.Reques
 func (s *gnomobileService) DeleteAccount(ctx context.Context, req *connect.Request[rpc.DeleteAccountRequest]) (*connect.Response[rpc.DeleteAccountResponse], error) {
 	if err := s.getSigner().Keybase.Delete(req.Msg.NameOrBech32, req.Msg.Password, req.Msg.SkipPassword); err != nil {
 		if keyerror.IsErrKeyNotFound(err) {
-			return nil, rpc.ErrCode_ErrCryptoKeyNotFound
+			return nil, rpc.ErrCode_ErrCryptoKeyNotFound.Grpc()
 		} else if keyerror.IsErrWrongPassword(err) {
-			return nil, rpc.ErrCode_ErrDecryptionFailed
+			return nil, rpc.ErrCode_ErrDecryptionFailed.Grpc()
 		} else {
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (s *gnomobileService) Call(ctx context.Context, req *connect.Request[rpc.Ca
 	s.lock.RLock()
 	if s.activeAccount == nil {
 		s.lock.RUnlock()
-		return nil, rpc.ErrCode_ErrNoActiveAccount
+		return nil, rpc.ErrCode_ErrNoActiveAccount.Grpc()
 	}
 	s.lock.RUnlock()
 
@@ -389,9 +389,9 @@ func (s *gnomobileService) Call(ctx context.Context, req *connect.Request[rpc.Ca
 	bres, err := s.client.Call(cfg)
 	if err != nil {
 		if errors.As(err, &std.UnknownAddressError{}) {
-			return nil, rpc.ErrCode_ErrUnknownAddress
+			return nil, rpc.ErrCode_ErrUnknownAddress.Grpc()
 		} else if keyerror.IsErrWrongPassword(err) {
-			return nil, rpc.ErrCode_ErrDecryptionFailed
+			return nil, rpc.ErrCode_ErrDecryptionFailed.Grpc()
 		} else {
 			return nil, err
 		}


### PR DESCRIPTION
The ConnectError object has a Details field that allows us to add our API error type next to the GRPC error (see [doc](https://connectrpc.com/docs/go/errors#error-details)).

In Go, before returning an API's type error, we have to encapsulate it in the ConnectError object, with the `.grpc()` method.
To handle the error correctly in React-Native, I added a GRPCError class. We can get the API's error code with the `.errCode()` method.