### PR TITLE
chore: In use-gno.ts call, add params send and memo

### DIFF
--- a/gnoboard/src/hooks/use-gno.ts
+++ b/gnoboard/src/hooks/use-gno.ts
@@ -47,7 +47,7 @@ interface GnoResponse {
   query: (path: string, data: Uint8Array) => Promise<QueryResponse>;
   render: (packagePath: string, args: string) => Promise<string>;
   qEval: (packagePath: string, expression: string) => Promise<string>;
-  call: (packagePath: string, fnc: string, args: Array<string>, gasFee: string, gasWanted: number) => Promise<CallResponse>;
+  call: (packagePath: string, fnc: string, args: Array<string>, gasFee: string, gasWanted: number, send?: string, memo?: string) => Promise<CallResponse>;
   addressToBech32: (address: Uint8Array) => Promise<string>;
   addressFromBech32: (bech32Address: string) => Promise<Uint8Array>;
 }
@@ -205,7 +205,7 @@ export const useGno = (): GnoResponse => {
     return reponse.result;
   };
 
-  const call = async (packagePath: string, fnc: string, args: Array<string>, gasFee: string, gasWanted: number) => {
+  const call = async (packagePath: string, fnc: string, args: Array<string>, gasFee: string, gasWanted: number, send?: string, memo?: string) => {
     const client = await getClient();
     const reponse = await client.call(
       new CallRequest({
@@ -214,6 +214,8 @@ export const useGno = (): GnoResponse => {
         args,
         gasFee,
         gasWanted: BigInt(gasWanted),
+        send,
+        memo,
       }),
     );
     return reponse;


### PR DESCRIPTION
In use-gno.ts, the helper method `call` creates a CallRequest which also has fields `send` and `memo`. We have not used these so far, but this PR adds them as params to `call`. These are optional final arguments, so this is backwards compatible with existing code.