### PR TITLE
chore: Set the default remote to 127.0.0.1. In useGno, initialize to testnet.gno.berty.io

### DIFF
--- a/gnoboard/src/hooks/use-gno.ts
+++ b/gnoboard/src/hooks/use-gno.ts
@@ -77,6 +77,10 @@ export const useGno = (): GnoResponse => {
 
     const port = await GoBridge.getTcpPort();
     clientInstance = Grpc.createClient(port);
+
+    // Set the initial configuration where it's different from the default.
+    await clientInstance.setRemote(new SetRemoteRequest({ remote: 'testnet.gno.berty.io:26657' }));
+
     return clientInstance;
   };
 

--- a/service/config.go
+++ b/service/config.go
@@ -73,7 +73,7 @@ var WithRemote = func(remote string) GnomobileOption {
 
 // WithDefaultRemote inits a default remote node address.
 var WithDefaultRemote GnomobileOption = func(cfg *Config) error {
-	cfg.Remote = "testnet.gno.berty.io:26657"
+	cfg.Remote = "127.0.0.1:26657"
 	return nil
 }
 


### PR DESCRIPTION
The doc for SetRemote says that the [default is 127.0.0.1](https://github.com/gnolang/gnomobile/blob/aaddabcb7a789b8f209afc83cddccac3d431893a/service/rpc/rpc.proto#L13) . This makes sense because the toolkit shouldn't be hardwired to a particular remote like the Berty testnet. However, at the moment, the gRPC service initializes the remote to the Berty testnet. But now the example app shows how to call SetRemote to change the network, so we don't need to be hardwired to the Berty testnet.

This PR changes the gRPC service so that the default remote is 127.0.0.1 . The useGno function is changed to set the remote to the Berty testnet for use by the app. (If the app is configured for a different default network, then this is where we can set it.)