### PR TITLE
feat: script to create new apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 # VSCode
 .vscode/
 jsconfig.json
+
+# Ignore any node_modules dir
+node_modules/

--- a/.tool-versions
+++ b/.tool-versions
@@ -5,3 +5,4 @@ java openjdk-18.0.1.1
 yarn 1.22.19
 golang 1.20.7
 buf 1.15.1
+jq 1.6

--- a/Makefile
+++ b/Makefile
@@ -159,3 +159,35 @@ asdf.install_tools: asdf.add_plugins
 	$(call check-program, asdf)
 	@echo "Installing asdf tools..."
 	@asdf install
+
+# - Example Apps
+
+NPM_BASIC_DEPENDENCIES := @bufbuild/protobuf @connectrpc/connect @connectrpc/connect-web
+
+new-app:
+ifndef APP_NAME
+	$(error APP_NAME is undefined. Please set APP_NAME to the name of your app)
+endif
+	@echo "creating a new gno awesome project"
+	cd examples && npx create-expo-app $(APP_NAME) --template expo-template-blank-typescript
+	@echo "Creating ios and android folders"
+	cd examples/$(APP_NAME) && npx expo prebuild
+	@echo "Installing npm dependencies"
+	cd examples/$(APP_NAME) && npm install ${NPM_BASIC_DEPENDENCIES}
+	Override react_native_dir for this target
+
+# create folders (api, grpc, hooks)
+	@mkdir -p ./examples/$(APP_NAME)/src/api
+	@mkdir -p ./examples/$(APP_NAME)/src/grpc
+	@mkdir -p ./examples/$(APP_NAME)/src/hooks
+# copy the essential files
+	@ cp -r $(react_native_dir)/src/api ./examples/$(APP_NAME)/src
+	@cp -r ./gnoboard/src/grpc examples/$(APP_NAME)/src/grpc
+	@cp -r ./gnoboard/src/hooks examples/$(APP_NAME)/src/hooks
+
+# generate the api
+	$(MAKE) generate react_native_dir=$(make_dir)/examples/$(APP_NAME)
+	$(MAKE) build.ios react_native_dir=$(make_dir)/examples/$(APP_NAME)
+	$(MAKE) build.android react_native_dir=$(make_dir)/examples/$(APP_NAME)
+.PHONY: new-app
+

--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ endif
 	@cp -r ./gnoboard/src/hooks examples/$(APP_NAME)/src
 	@cp -r ./gnoboard/src/native_modules examples/$(APP_NAME)/src
 	@cp ./templates/tsconfig.json examples/$(APP_NAME)/tsconfig.json
+	$(MAKE) add-app-json-entry
 
 # generate the api. Override react_native_dir for this target
 	$(MAKE) generate react_native_dir=$(make_dir)/examples/$(APP_NAME)
@@ -193,3 +194,8 @@ endif
 	$(MAKE) build.android react_native_dir=$(make_dir)/examples/$(APP_NAME)
 .PHONY: new-app
 
+JSON_FILE := $(make_dir)/examples/$(APP_NAME)/app.json
+add-app-json-entry:
+	@echo "Adding tsconfigPaths entry to app.json"
+	jq '.expo.experiments = {"tsconfigPaths": true}'  $(JSON_FILE) > $(JSON_FILE).tmp && mv $(JSON_FILE).tmp  $(JSON_FILE)
+.PHONY: add-app-json-entry

--- a/Makefile
+++ b/Makefile
@@ -168,24 +168,24 @@ new-app:
 ifndef APP_NAME
 	$(error APP_NAME is undefined. Please set APP_NAME to the name of your app)
 endif
+	@mkdir -p ./examples/
 	@echo "creating a new gno awesome project"
 	cd examples && npx create-expo-app $(APP_NAME) --template expo-template-blank-typescript
 	@echo "Creating ios and android folders"
 	cd examples/$(APP_NAME) && npx expo prebuild
 	@echo "Installing npm dependencies"
 	cd examples/$(APP_NAME) && npm install ${NPM_BASIC_DEPENDENCIES}
-	Override react_native_dir for this target
 
 # create folders (api, grpc, hooks)
 	@mkdir -p ./examples/$(APP_NAME)/src/api
 	@mkdir -p ./examples/$(APP_NAME)/src/grpc
 	@mkdir -p ./examples/$(APP_NAME)/src/hooks
 # copy the essential files
-	@ cp -r $(react_native_dir)/src/api ./examples/$(APP_NAME)/src
+	@cp -r $(react_native_dir)/src/api ./examples/$(APP_NAME)/src/api
 	@cp -r ./gnoboard/src/grpc examples/$(APP_NAME)/src/grpc
 	@cp -r ./gnoboard/src/hooks examples/$(APP_NAME)/src/hooks
 
-# generate the api
+# generate the api. Override react_native_dir for this target
 	$(MAKE) generate react_native_dir=$(make_dir)/examples/$(APP_NAME)
 	$(MAKE) build.ios react_native_dir=$(make_dir)/examples/$(APP_NAME)
 	$(MAKE) build.android react_native_dir=$(make_dir)/examples/$(APP_NAME)

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ endif
 	@cp ./templates/tsconfig.json ./examples/$(APP_NAME)/tsconfig.json
 	$(MAKE) add-app-json-entry
 # copy ios Sources	
-	@cp -r $(react_native_dir)/ios/gnoboard/Sources ./examples/$(APP_NAME)/ios/$(APP_NAME)
+	@cp -r $(react_native_dir)/ios/gnoboard/Sources ./examples/$(APP_NAME)/ios/$(APP_NAME)/
 	@cp $(react_native_dir)/ios/gnoboard/gnoboard-Bridging-Header.h ./examples/$(APP_NAME)/ios/$(APP_NAME)/$(APP_NAME)-Bridging-Header.h
 	@cp -r $(react_native_dir)/ios/Sources ./examples/$(APP_NAME)/ios/
 

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ endif
 	$(MAKE) add-app-json-entry
 # copy ios Sources	
 	@cp -r $(react_native_dir)/ios/gnoboard/Sources ./examples/$(APP_NAME)/ios/$(APP_NAME)
-	@cp $(react_native_dir)/ios/gnoboard/gnoboard-Bridging-Header.h ./examples/$(APP_NAME)/ios/$(APP_NAME)-Bridging-Header.h
+	@cp $(react_native_dir)/ios/gnoboard/gnoboard-Bridging-Header.h ./examples/$(APP_NAME)/ios/$(APP_NAME)/$(APP_NAME)-Bridging-Header.h
 	@cp -r $(react_native_dir)/ios/Sources ./examples/$(APP_NAME)/ios/
 
 # generate the api. Override react_native_dir for this target

--- a/Makefile
+++ b/Makefile
@@ -181,9 +181,11 @@ endif
 	@mkdir -p ./examples/$(APP_NAME)/src/grpc
 	@mkdir -p ./examples/$(APP_NAME)/src/hooks
 # copy the essential files
-	@cp -r $(react_native_dir)/src/api ./examples/$(APP_NAME)/src/api
-	@cp -r ./gnoboard/src/grpc examples/$(APP_NAME)/src/grpc
-	@cp -r ./gnoboard/src/hooks examples/$(APP_NAME)/src/hooks
+	@cp -r $(react_native_dir)/src/api ./examples/$(APP_NAME)/src
+	@cp -r ./gnoboard/src/grpc examples/$(APP_NAME)/src
+	@cp -r ./gnoboard/src/hooks examples/$(APP_NAME)/src
+	@cp -r ./gnoboard/src/native_modules examples/$(APP_NAME)/src
+	@cp ./templates/tsconfig.json examples/$(APP_NAME)/tsconfig.json
 
 # generate the api. Override react_native_dir for this target
 	$(MAKE) generate react_native_dir=$(make_dir)/examples/$(APP_NAME)

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ asdf.install_tools: asdf.add_plugins
 
 # - Example Apps
 
-NPM_BASIC_DEPENDENCIES := @bufbuild/protobuf @connectrpc/connect @connectrpc/connect-web
+NPM_BASIC_DEPENDENCIES := @bufbuild/protobuf @connectrpc/connect @connectrpc/connect-web react-native-polyfill-globals react-native-url-polyfill web-streams-polyfill react-native-get-random-values text-encoding base-64 react-native-fetch-api
 
 new-app:
 ifndef APP_NAME
@@ -189,6 +189,7 @@ endif
 	@cp ./templates/tsconfig.json ./examples/$(APP_NAME)/tsconfig.json
 	$(MAKE) add-app-json-entry
 # copy ios Sources	
+	@mkdir -p ./examples/$(APP_NAME)/ios/$(APP_NAME)/Sources
 	@cp -r $(react_native_dir)/ios/gnoboard/Sources ./examples/$(APP_NAME)/ios/$(APP_NAME)/
 	@cp $(react_native_dir)/ios/gnoboard/gnoboard-Bridging-Header.h ./examples/$(APP_NAME)/ios/$(APP_NAME)/$(APP_NAME)-Bridging-Header.h
 	@cp -r $(react_native_dir)/ios/Sources ./examples/$(APP_NAME)/ios/

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,10 @@ PATH := $(GO_BIND_BIN_DIR):$(PATH)
 all build: generate build.ios build.android
 
 # Build iOS framework
+APP_NAME := "gnoboard"
 build.ios: generate $(gnocore_xcframework)
 	cd $(react_native_dir); $(MAKE) node_modules
-	cd $(react_native_dir); $(MAKE) ios/gnoboard.xcworkspace
+	cd $(react_native_dir); $(MAKE) ios/$(APP_NAME).xcworkspace
 
 # Build Android aar & jar
 build.android: generate $(gnocore_aar) $(gnocore_jar)
@@ -182,11 +183,15 @@ endif
 	@mkdir -p ./examples/$(APP_NAME)/src/hooks
 # copy the essential files
 	@cp -r $(react_native_dir)/src/api ./examples/$(APP_NAME)/src
-	@cp -r ./gnoboard/src/grpc examples/$(APP_NAME)/src
-	@cp -r ./gnoboard/src/hooks examples/$(APP_NAME)/src
-	@cp -r ./gnoboard/src/native_modules examples/$(APP_NAME)/src
-	@cp ./templates/tsconfig.json examples/$(APP_NAME)/tsconfig.json
+	@cp -r ./gnoboard/src/grpc ./examples/$(APP_NAME)/src
+	@cp -r ./gnoboard/src/hooks ./examples/$(APP_NAME)/src
+	@cp -r ./gnoboard/src/native_modules ./examples/$(APP_NAME)/src
+	@cp ./templates/tsconfig.json ./examples/$(APP_NAME)/tsconfig.json
 	$(MAKE) add-app-json-entry
+# copy ios Sources	
+	@cp -r $(react_native_dir)/ios/gnoboard/Sources ./examples/$(APP_NAME)/ios/$(APP_NAME)
+	@cp $(react_native_dir)/ios/gnoboard/gnoboard-Bridging-Header.h ./examples/$(APP_NAME)/ios/$(APP_NAME)-Bridging-Header.h
+	@cp -r $(react_native_dir)/ios/Sources ./examples/$(APP_NAME)/ios/
 
 # generate the api. Override react_native_dir for this target
 	$(MAKE) generate react_native_dir=$(make_dir)/examples/$(APP_NAME)

--- a/docs/getting-started/create-new-app.md
+++ b/docs/getting-started/create-new-app.md
@@ -1,0 +1,55 @@
+# Create a new App
+
+## Overview
+
+This guide will walk you through creating a new Gno Mobile App using the `create-app` command.
+
+## Prerequisites
+
+Check the [Build instruction](../../README.md#build-instructions) guide for prerequisites.
+
+## Create a new App
+
+To create a new app, run the following command:
+
+```console
+cd gnomobile (root of the repo)
+make create-app APP_NAME=MyApp
+```
+
+This will create a new app in the `examples/MyApp` directory containing a basic integration with Gno.
+
+## Run the App
+
+To run the app, run the following command:
+
+```console
+cd examples/MyApp
+yarn start
+```
+and then run the following command in another terminal:
+
+```console
+cd examples/MyApp
+npx react-native [run-android|run-ios]
+```
+
+## Using Gno in your App
+
+To use Gno in your app, you can import the `useGno` hook from `@gno/hooks/use-gno`:
+
+```ts
+import { useGno } from '@gno/hooks/use-gno';
+
+export default function App() {
+  const gno = useGno();
+
+  React.useEffect(() => {
+    gno.getRemote()
+    .then(res => console.log(res))
+    .catch(err => console.log(err));
+  }, []);
+
+...
+
+```

--- a/docs/getting-started/create-new-app.md
+++ b/docs/getting-started/create-new-app.md
@@ -51,5 +51,3 @@ export default function App() {
   }, []);
 
 ...
-
-```

--- a/gen.sum
+++ b/gen.sum
@@ -1,4 +1,4 @@
-e7afb7d237ea0d39ee9a30df34e8262def4551f0  Makefile
+0459c51f8f58cdb93b5c5aeccb2fd54592576573  Makefile
 de947d5bd943bc6295fed5ad70ecb81547245997  buf.gen.yaml
 111044c0f7fcae95336c33355feda6eb476d7b74  service/gnomobiletypes/gnomobiletypes.go
 d5425375a601ed0835d91f98cf85ae36d1eb6c0f  service/gnomobiletypes/package.go

--- a/gen.sum
+++ b/gen.sum
@@ -1,4 +1,4 @@
-1e6bd8724e72bd2ac0826580baefa8361925ddeb  Makefile
+e7afb7d237ea0d39ee9a30df34e8262def4551f0  Makefile
 de947d5bd943bc6295fed5ad70ecb81547245997  buf.gen.yaml
 111044c0f7fcae95336c33355feda6eb476d7b74  service/gnomobiletypes/gnomobiletypes.go
 d5425375a601ed0835d91f98cf85ae36d1eb6c0f  service/gnomobiletypes/package.go

--- a/templates/tsconfig.json
+++ b/templates/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@gno/*": ["src/*"],
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new script (makefile) to allow users to create new apps into the /examples folder.
The idea is to allow users to run:

$ make new-app APP_NAME=my-wallet

And then automagically the script creates a new app into /examples/my-wallet ready to connect into the gno blockchain.

The main script parts are:

1 - create a new react native using expo scripts
2 - copy the essentials folders from gnoboard
3 - generate the code as gnoboard do